### PR TITLE
Use onItemUseFinish event for FoodContainerItem

### DIFF
--- a/src/main/java/com/kevun1/solpotato/item/foodcontainer/FoodContainerItem.java
+++ b/src/main/java/com/kevun1/solpotato/item/foodcontainer/FoodContainerItem.java
@@ -11,6 +11,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
@@ -110,7 +111,8 @@ public class FoodContainerItem extends Item {
 
         ItemStack bestFood = handler.getStackInSlot(bestFoodSlot);
         if (bestFood.isFood() && !bestFood.isEmpty()) {
-            ItemStack result = bestFood.onItemUseFinish(world, entity);
+            ItemStack result = ForgeEventFactory.onItemUseFinish(player, bestFood.copy(),
+                player.getItemInUseCount(), bestFood.onItemUseFinish(player.world, player));
             // put bowls/bottles etc. into player inventory
             if (!result.isFood()) {
                 handler.setStackInSlot(bestFoodSlot, ItemStack.EMPTY);


### PR DESCRIPTION
Addresses https://github.com/Kevun1/Spice-of-Life-Potato-Edition/issues/14

This is a small change that allows the lunchboxes to integrate with the Diet mod's nutrition system, as well as providing compatibility with any other mod that hooks into the event for any item that is consumed by the lunchbox.

I did some preliminary testing with foods and bowls to make sure this doesn't break basic functionality and all seems good with no change in behavior other than enhanced compatibility.